### PR TITLE
chore: update connector pkg version and rename `json` to `structured_data`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/instill-ai/connector v0.0.0-20230626100237-5ecbb3c4c57a
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230626081036-adbc33794c42
+	github.com/instill-ai/connector v0.0.0-20230627145616-46d38fd71ac8
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230627140850-cfd958552c23
 	go.uber.org/zap v1.24.0
 	google.golang.org/protobuf v1.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,10 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbskOL6tDC5jMSyx3zxE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAszqCJMbfTISJ7oMftp8+UGV08=
-github.com/instill-ai/connector v0.0.0-20230626100237-5ecbb3c4c57a h1:CpMdixXmtZ7sv6eMbTnXRbKOPwXEMI38TODua+Kpf2o=
-github.com/instill-ai/connector v0.0.0-20230626100237-5ecbb3c4c57a/go.mod h1:m+xoiWEQElLcxGuYdU9wb+DVD6rQ1g72xHYyOW0m+Ek=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230626081036-adbc33794c42 h1:mmRaW6Tz/j2jqoKCGvo3V1HK4aCxs3/RDOaDjrWMvAo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230626081036-adbc33794c42/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/connector v0.0.0-20230627145616-46d38fd71ac8 h1:mdZGyOMLFMNKsyWlat1e5QUUL1KsC1zN9HYZw+S5UKk=
+github.com/instill-ai/connector v0.0.0-20230627145616-46d38fd71ac8/go.mod h1:IqLjZ5zc854JeCXM4cz6jlbZeM0n5qgqkMO1qj6Xekk=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230627140850-cfd958552c23 h1:KiCIryxQb22byMZj9fQCiAO5L1M+N/LU6BaL121Toy4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230627140850-cfd958552c23/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/numbers/config/seed/definitions.json
+++ b/pkg/numbers/config/seed/definitions.json
@@ -18,7 +18,7 @@
           "license",
           "asset_type",
           "metadata_texts",
-          "metadata_json",
+          "metadata_structured_data",
           "metadata_metadata"
         ],
         "additionalProperties": false,
@@ -51,9 +51,9 @@
             "type": "boolean",
             "default": false
           },
-          "metadata_json": {
-            "title": "Add input json to Blockchain's metadata",
-            "description": "Add the json input as the metadata to Blockchain",
+          "metadata_structured_data": {
+            "title": "Add input structured_data to Blockchain's metadata",
+            "description": "Add the structured_data input as the metadata to Blockchain",
             "type": "boolean",
             "default": false
           },


### PR DESCRIPTION
Because

- the base connector pkg was updated 

This commit

- update connector pkg version
- rename `json` to `structured_data`
