### PR TITLE
feat: add numbers icon config

### DIFF
--- a/pkg/numbers/config/seed/definitions.json
+++ b/pkg/numbers/config/seed/definitions.json
@@ -2,7 +2,7 @@
   {
     "custom": false,
     "documentationUrl": "https://www.instill.tech/docs/connectors/numbers-blockchain-nit",
-    "icon": "",
+    "icon": "numbers.svg",
     "iconUrl": "",
     "id": "numbers-blockchain-nit",
     "public": true,


### PR DESCRIPTION
Because

- console need this field to correctly generate icon image for numbers 

This commit

- add numbers icon config
