### PR TITLE
chore: update definition and support upload structured_data, metadata, texts into blockchain

### DIFF
--- a/pkg/numbers/config/seed/definitions.json
+++ b/pkg/numbers/config/seed/definitions.json
@@ -4,7 +4,7 @@
     "documentationUrl": "https://www.instill.tech/docs/connectors/numbers-blockchain-nit",
     "icon": "numbers.svg",
     "iconUrl": "",
-    "id": "numbers-blockchain-nit",
+    "id": "blockchain-numbers",
     "public": true,
     "spec": {
       "documentationUrl": "https://www.instill.tech/docs/connectors/numbers-blockchain-nit",
@@ -14,8 +14,6 @@
         "type": "object",
         "required": [
           "capture_token",
-          "creator_name",
-          "license",
           "asset_type",
           "metadata_texts",
           "metadata_structured_data",
@@ -28,16 +26,6 @@
             "description": "Capture token from NumbersProtocol",
             "type": "string",
             "credential_field": true
-          },
-          "creator_name": {
-            "title": "Creator Name",
-            "description": "Name of the creator who owns the Web3 asset",
-            "type": "string"
-          },
-          "license": {
-            "title": "License",
-            "description": "License of the Web3 asset",
-            "type": "string"
           },
           "asset_type": {
             "title": "Asset type",
@@ -67,7 +55,7 @@
         }
       }
     },
-    "title": "NIT",
+    "title": "NumbersProtocol",
     "tombstone": false,
     "uid": "70d8664a-d512-4517-a5e8-5d4da81756a7",
     "vendorAttributes": {}


### PR DESCRIPTION
Because

- need to write some metadata into blockchain

This commit

- update definition
- support upload structured_data, metadata, texts into blockchain
