### PR TITLE
chore: fix json-schema bug

### DIFF
--- a/pkg/numbers/config/definitions.json
+++ b/pkg/numbers/config/definitions.json
@@ -43,7 +43,7 @@
                 "instillUpstreamTypes": [
                   "reference"
                 ],
-                "oneOf": [
+                "anyOf": [
                   {
                     "type": "string",
                     "pattern": "^\\{.*\\}$",
@@ -59,7 +59,7 @@
                   "value",
                   "reference"
                 ],
-                "oneOf": [
+                "anyOf": [
                   {
                     "type": "string",
                     "instillUpstreamType": "value"
@@ -79,7 +79,7 @@
                   "value",
                   "reference"
                 ],
-                "oneOf": [
+                "anyOf": [
                   {
                     "type": "string",
                     "instillUpstreamType": "value"
@@ -103,7 +103,7 @@
                       "value",
                       "reference"
                     ],
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "type": "string",
                         "enum": [
@@ -131,7 +131,7 @@
                       "value",
                       "reference"
                     ],
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "type": "string",
                         "enum": [
@@ -161,7 +161,7 @@
                       "value",
                       "reference"
                     ],
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "type": "string",
                         "default": "https://console.instill.tech",
@@ -182,7 +182,7 @@
                       "value",
                       "reference"
                     ],
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "type": "string",
                         "instillUpstreamType": "value"
@@ -202,7 +202,7 @@
                       "value",
                       "reference"
                     ],
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "type": "string",
                         "instillUpstreamType": "value"
@@ -226,7 +226,7 @@
                           "value",
                           "reference"
                         ],
-                        "oneOf": [
+                        "anyOf": [
                           {
                             "type": "string",
                             "instillUpstreamType": "value"
@@ -246,7 +246,7 @@
                           "value",
                           "reference"
                         ],
-                        "oneOf": [
+                        "anyOf": [
                           {
                             "type": "string",
                             "instillUpstreamType": "value"

--- a/pkg/numbers/config/seed/generate_definitions.py
+++ b/pkg/numbers/config/seed/generate_definitions.py
@@ -119,15 +119,15 @@ def convert_field(field):
             "description": field.get("description", ""),
             "instillFormat": field["instillFormat"],
             "instillUpstreamTypes": field["instillUpstreamTypes"],
-            "oneOf": []
+            "anyOf": []
         }
 
         for instillUpstreamType in instill_upstream_types:
             if instillUpstreamType == "value":
                 original_field["instillUpstreamType"] = instillUpstreamType
-                field["oneOf"].append(original_field)
+                field["anyOf"].append(original_field)
             if instillUpstreamType == "reference":
-                field["oneOf"].append({
+                field["anyOf"].append({
                     "type": "string",
                     "pattern": "^\\{.*\\}$",
                     "instillUpstreamType": instillUpstreamType


### PR DESCRIPTION
Because

- we should use `anyOf` in json-schema rather than `oneOf`

This commit

- fix json-schema bug
