### PR TITLE
chore: support uploading pipeline and owner as metadata

### DIFF
--- a/pkg/numbers/config/definitions.json
+++ b/pkg/numbers/config/definitions.json
@@ -259,6 +259,77 @@
                         ]
                       }
                     }
+                  },
+                  "metadata": {
+                    "title": "Metadata",
+                    "type": "object",
+                    "properties": {
+                      "pipeline": {
+                        "title": "Pipeline",
+                        "type": "object",
+                        "properties": {
+                          "uid": {
+                            "title": "Pipeline UID",
+                            "description": "",
+                            "instillFormat": "text",
+                            "instillUpstreamTypes": [
+                              "reference"
+                            ],
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "pattern": "^\\{.*\\}$",
+                                "instillUpstreamType": "reference"
+                              }
+                            ]
+                          },
+                          "name": {
+                            "title": "Pipeline Name",
+                            "description": "",
+                            "instillFormat": "text",
+                            "instillUpstreamTypes": [
+                              "reference"
+                            ],
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "pattern": "^\\{.*\\}$",
+                                "instillUpstreamType": "reference"
+                              }
+                            ]
+                          },
+                          "recipe": {
+                            "title": "Pipeline Recipe",
+                            "type": "object",
+                            "instillFormat": "object",
+                            "instillUpstreamTypes": [
+                              "reference"
+                            ]
+                          }
+                        }
+                      },
+                      "owner": {
+                        "title": "Owner",
+                        "type": "object",
+                        "properties": {
+                          "uid": {
+                            "title": "Owner UID",
+                            "description": "",
+                            "instillFormat": "text",
+                            "instillUpstreamTypes": [
+                              "reference"
+                            ],
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "pattern": "^\\{.*\\}$",
+                                "instillUpstreamType": "reference"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -410,6 +481,56 @@
                                             "value",
                                             "reference"
                                           ]
+                                        }
+                                      }
+                                    },
+                                    "metadata": {
+                                      "title": "Metadata",
+                                      "type": "object",
+                                      "properties": {
+                                        "pipeline": {
+                                          "title": "Pipeline",
+                                          "type": "object",
+                                          "properties": {
+                                            "uid": {
+                                              "title": "Pipeline UID",
+                                              "type": "string",
+                                              "instillFormat": "text",
+                                              "instillUpstreamTypes": [
+                                                "reference"
+                                              ]
+                                            },
+                                            "name": {
+                                              "title": "Pipeline Name",
+                                              "type": "string",
+                                              "instillFormat": "text",
+                                              "instillUpstreamTypes": [
+                                                "reference"
+                                              ]
+                                            },
+                                            "recipe": {
+                                              "title": "Pipeline Recipe",
+                                              "type": "object",
+                                              "instillFormat": "object",
+                                              "instillUpstreamTypes": [
+                                                "reference"
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "owner": {
+                                          "title": "Owner",
+                                          "type": "object",
+                                          "properties": {
+                                            "uid": {
+                                              "title": "Owner UID",
+                                              "type": "string",
+                                              "instillFormat": "text",
+                                              "instillUpstreamTypes": [
+                                                "reference"
+                                              ]
+                                            }
+                                          }
                                         }
                                       }
                                     }

--- a/pkg/numbers/config/seed/data.json
+++ b/pkg/numbers/config/seed/data.json
@@ -97,6 +97,48 @@
                   "instillUpstreamTypes": ["value", "reference"]
                 }
               }
+            },
+            "metadata": {
+              "title": "Metadata",
+              "type": "object",
+              "properties": {
+                "pipeline": {
+                  "title": "Pipeline",
+                  "type": "object",
+                  "properties": {
+                    "uid": {
+                      "title": "Pipeline UID",
+                      "type": "string",
+                      "instillFormat": "text",
+                      "instillUpstreamTypes": ["reference"]
+                    },
+                    "name": {
+                      "title": "Pipeline Name",
+                      "type": "string",
+                      "instillFormat": "text",
+                      "instillUpstreamTypes": ["reference"]
+                    },
+                    "recipe": {
+                      "title": "Pipeline Recipe",
+                      "type": "object",
+                      "instillFormat": "object",
+                      "instillUpstreamTypes": ["reference"]
+                    }
+                  }
+                },
+                "owner": {
+                  "title": "Owner",
+                  "type": "object",
+                  "properties": {
+                    "uid": {
+                      "title": "Owner UID",
+                      "type": "string",
+                      "instillFormat": "text",
+                      "instillUpstreamTypes": ["reference"]
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/pkg/numbers/main.go
+++ b/pkg/numbers/main.go
@@ -59,6 +59,15 @@ type CommitCustom struct {
 	GeneratedBy       *string              `json:"generatedBy,omitempty"`
 	CreatorWallet     *string              `json:"creatorWallet,omitempty"`
 	License           *CommitCustomLicense `json:"license,omitempty"`
+	Metadata          *struct {
+		Pipeline *struct {
+			Uid    *string     `json:"uid,omitempty"`
+			Recipe interface{} `json:"recipe,omitempty"`
+		} `json:"pipeline,omitempty"`
+		Owner *struct {
+			Uid *string `json:"uid,omitempty"`
+		} `json:"owner,omitempty"`
+	} `json:"instillMetadata,omitempty"`
 }
 type Commit struct {
 	AssetCid              string        `json:"assetCid"`
@@ -85,6 +94,15 @@ type Input struct {
 			Name     *string `json:"name,omitempty"`
 			Document *string `json:"document,omitempty"`
 		} `json:"license,omitempty"`
+		Metadata *struct {
+			Pipeline *struct {
+				Uid    *string     `json:"uid,omitempty"`
+				Recipe interface{} `json:"recipe,omitempty"`
+			} `json:"pipeline,omitempty"`
+			Owner *struct {
+				Uid *string `json:"uid,omitempty"`
+			} `json:"owner,omitempty"`
+		} `json:"metadata,omitempty"`
 	} `json:"custom,omitempty"`
 }
 
@@ -299,6 +317,7 @@ func (con *Connection) Execute(inputs []*structpb.Struct) ([]*structpb.Struct, e
 					GeneratedBy:       inputStruct.Custom.GeneratedBy,
 					CreatorWallet:     inputStruct.Custom.CreatorWallet,
 					License:           commitCustomLicense,
+					Metadata:          inputStruct.Custom.Metadata,
 				}
 
 			}


### PR DESCRIPTION
Because

- we need to upload the pipeline and owner as metadata to blockchain

This commit

- support uploading pipeline and owner as metadata
